### PR TITLE
fix(deasync): update to 0.1.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/rsrdesarrollo/node-fqdn#readme",
   "dependencies": {
-    "deasync": "^0.1.7"
+    "deasync": "^0.1.12"
   }
 }


### PR DESCRIPTION
Pulling in a higher version of deasync which has a fix for the process._tickDomainCallback is not a function https://github.com/abbr/deasync/issues/89